### PR TITLE
change from recommending creating a Plugins folder to recommending using the already existing Libraries folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A mod loader for [Neos VR](https://neos.com/).
 ## Installation
 If you are using the Steam version of Neos you are in the right place. If you are using the standalone version, [read these extra instructions](doc/neos_standalone_setup.md).
 
-1. Download [NeosModLoader.dll](https://github.com/zkxs/NeosModLoader/releases/latest/download/NeosModLoader.dll) to a location of your choosing. I recommend putting it in a `Plugins` folder in your Neos install folder.
+1. Download [NeosModLoader.dll](https://github.com/zkxs/NeosModLoader/releases/latest/download/NeosModLoader.dll) to a location of your choosing. I recommend putting it in the `Libraries` folder within your Neos install directory.
 2. Place [0Harmony.dll](https://github.com/zkxs/NeosModLoader/releases/download/1.0.0.0/0Harmony.dll) in your Neos install directory (`C:\Program Files (x86)\Steam\steamapps\common\NeosVR`).
 3. Add mod DLL files to a `nml_mods` folder under your Neos install directory (`C:\Program Files (x86)\Steam\steamapps\common\NeosVR\nml_mods`). You can create the folder if it's missing, or simply launch Neos once with NeosModLoader installed and it will be created automatically.
 4. Add the following to Neos's [launch options](https://wiki.neos.com/Command_Line_Arguments): `-LoadAssembly "C:\full\path\to\NeosModLoader.dll"`, substituting the path for wherever you put `NeosModLoader.dll`. You can also use a relative path here, with `Neos.exe` as the starting point.
@@ -27,13 +27,13 @@ Your Neos directory should now look like the following. Files not related to mod
 │       MotionBlurDisable.dll
 │       NeosContactsSort.dll
 │
-└───Plugins
+└───Libraries
         NeosModLoader.dll
 ```
 
 With this setup, the following launch options would be used. Note the use of a relative path to `NeosModLoader.dll`.
 ```
--LoadAssembly "Plugins\NeosModLoader.dll"
+-LoadAssembly "Libraries\NeosModLoader.dll"
 ```
 
 


### PR DESCRIPTION
in my opinion using the Libraries folder is better than creating a Plugins folder because
1. the folder already exists so one less step 
2. will show in the list of loadable plugins for the launcher 
![Annotation 2021-11-10 151516](https://user-images.githubusercontent.com/17285570/141208785-2c2987bd-fe16-4b23-80cd-79e486a061cf.jpg)
