### PR TITLE
Misc cleanup

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,21 +1,27 @@
 # NeosModLoader Contributing Guidelines
+
 If you are interested in contributing to this project via issues or PRs, please follow these guidelines.
 
 ## Issue Guidelines
+
 If you are reporting a bug, please include a log, or at the very least the relevant stack trace. NeosModLoader logs to the Neos log by default (`C:\Program Files (x86)\Steam\steamapps\common\NeosVR\Logs`).
 
 ## PR Guidelines
+
 If you want your PR to be approved and merged quickly, please read the following:
 
 ### Branches
+
 PRs should be made onto the `dev` branch. PRs made on to other branches, including master, will be subject to delays as changing their base branch to `dev` may introduce merge conflicts.
 
 ### Code Style
+
 If your PR does not follow the project's code style it **will not be approved**. I expect contributors to be capable of fixing code style issues on their own.
 
 Code style should match Microsoft convention. If you aren't sure, run Analyze > Code Cleanup on the file using Visual Studio.
 
 #### Whitespace
+
 - *.cs files
   - Lines MUST be indented using four spaces. Tabs are not acceptable.
   - MUST use unix-style (LF) line endings. CR or CRLF are not acceptable.
@@ -27,9 +33,11 @@ Code style should match Microsoft convention. If you aren't sure, run Analyze > 
   - CRLF line endings
 
 ### New Features
+
 Please consider the NML [design goals](#design-goals) before adding a new feature. If you aren't sure if your new feature makes sense for NML, I'm happy to talk with you about a potential new feature in our [discussions area](https://github.com/zkxs/NeosModLoader/discussions).
 
 ## Design Goals
+
 - NML should be kept as simple as possible. Its purpose is to load mods, not mod Neos itself. Additionally, NML is not intended to fix Neos bugs. Please do not attempt to add Neos bugfixes directly to NML. Instead, ensure there's an issue open on [the Neos issue tracker](https://github.com/Neos-Metaverse/NeosPublic/issues), and only consider making a mod if the Neos team is unable to provide a fix in a reasonably timeframe.
 - NML should only create APIs where the added API complexity is paid for by added ease of development for mod creators. If a proposed API is only useful to a very small percentage of mods, NeosModLoader probably isn't the place for it.
 - NML should try to prevent mod developers from shooting themselves in the foot. For example, NML only supports mods with a single NeosMod implementation. Instead of silently ignoring extra implementations in a mod, NML will instead throw an error message and abort loading the mod entirely.

--- a/NeosModLoader/NeosModLoader.csproj
+++ b/NeosModLoader/NeosModLoader.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Lib.Harmony" Version="2.2.0" />
+    <PackageReference Include="Lib.Harmony" Version="2.2.1" />
     <Reference Include="BaseX">
       <HintPath>$(NeosPath)Neos_Data\Managed\BaseX.dll</HintPath>
     </Reference>

--- a/NeosModLoader/NeosModLoader.csproj
+++ b/NeosModLoader/NeosModLoader.csproj
@@ -5,7 +5,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NeosModLoader</RootNamespace>
     <AssemblyTitle>NeosModLoader</AssemblyTitle>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo> 
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <TargetFramework>net462</TargetFramework>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
@@ -31,6 +31,6 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(CopyToPlugins)'=='true'">
-      <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(NeosPath)Libraries" />
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(NeosPath)Libraries" />
   </Target>
 </Project>

--- a/NeosModLoader/NeosModLoader.csproj
+++ b/NeosModLoader/NeosModLoader.csproj
@@ -12,7 +12,7 @@
     <NeosPath>$(MSBuildThisFileDirectory)NeosVR</NeosPath>
     <NeosPath Condition="Exists('C:\Program Files (x86)\Steam\steamapps\common\NeosVR\')">C:\Program Files (x86)\Steam\steamapps\common\NeosVR\</NeosPath>
     <NeosPath Condition="Exists('$(HOME)/.steam/steam/steamapps/common/NeosVR/')">$(HOME)/.steam/steam/steamapps/common/NeosVR/</NeosPath>
-    <CopyToPlugins Condition="'$(CopyToPlugins)'==''">true</CopyToPlugins>
+    <CopyToLibraries Condition="'$(CopyToLibraries)'==''">true</CopyToLibraries>
     <DebugSymbols Condition="'$(Configuration)'=='Release'">false</DebugSymbols>
     <DebugType Condition="'$(Configuration)'=='Release'">None</DebugType>
   </PropertyGroup>
@@ -30,7 +30,7 @@
     </Reference>
   </ItemGroup>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(CopyToPlugins)'=='true'">
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(CopyToLibraries)'=='true'">
     <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(NeosPath)Libraries" />
   </Target>
 </Project>

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 A mod loader for [Neos VR](https://neos.com/). Consider joining our community on [Discord][Neos Modding Discord] for support, updates, and more.
 
 ## Installation
+
 If you are using the Steam version of Neos you are in the right place. If you are using the standalone version, read the [Neos Standalone Setup](doc/neos_standalone_setup.md) instructions. If you are on Linux, read the [Linux Notes](doc/linux.md).
 
 1. Download [NeosModLoader.dll](https://github.com/zkxs/NeosModLoader/releases/latest/download/NeosModLoader.dll) to Neos's `Libraries` folder (`C:\Program Files (x86)\Steam\steamapps\common\NeosVR\Libraries`).
@@ -14,7 +15,9 @@ If you are using the Steam version of Neos you are in the right place. If you ar
 If NeosModLoader isn't working after following those steps, take a look at our [troubleshooting page](doc/troubleshooting.md).
 
 ### Example Directory Structure
+
 Your Neos directory should now look similar to the following. Files not related to modding are not shown.
+
 ```
 <Neos Install Directory>
 │   0Harmony.dll
@@ -35,18 +38,23 @@ Your Neos directory should now look similar to the following. Files not related 
 ```
 
 ## Finding Mods
+
 A list of known mods is available in the [Neos Mod List](https://github.com/zkxs/neos-mod-list/blob/master/README.md). New mods and updates are also announced in [our Discord][Neos Modding Discord].
 
 ## Frequently Asked Questions
+
 Many questions about what NML is and how it works are answered on our [frequently asked questions page](doc/faq.md).
 
 ## Making a Mod
+
 Check out the [Mod Creation Guide](doc/making_mods.md).
 
 ## Configuration
+
 NeosModLoader aims to have a reasonable default configuration, but certain things can be adjusted via an [optional config file](doc/modloader_config.md).
 
 ## Contributing
+
 Issues and PRs are welcome. Please read our [Contributing Guidelines](.github/CONTRIBUTING.md)!
 
 ## Licensing and Credits
@@ -54,9 +62,11 @@ Issues and PRs are welcome. Please read our [Contributing Guidelines](.github/CO
 NeosModLoader is licensed under the GNU Lesser General Public License (LGPL). See [LICENSE.txt](LICENSE.txt) for the full license.
 
 Third-party libraries distributed alongside NeosModLoader:
+
 - [LibHarmony] ([MIT License](https://github.com/pardeike/Harmony/blob/79d62b42c71d005b3cb1d94e741bfd4ce7e03a6b/LICENSE))
 
 Third-party libraries used in source:
+
 - [.NET](https://github.com/dotnet) (Various licenses)
 - [Neos VR](https://neos.com/) ([EULA](https://store.steampowered.com//eula/740250_eula_0))
 - [Json.NET](https://github.com/JamesNK/Newtonsoft.Json) ([MIT License](https://github.com/JamesNK/Newtonsoft.Json/blob/52190a3a3de6ef9a556583cbcb2381073e7197bc/LICENSE.md))

--- a/doc/config.md
+++ b/doc/config.md
@@ -22,7 +22,6 @@ Behind the scenes, configs are saved to a `nml_config` folder in the Neos instal
 - Reading/writing configuration values is done in-memory and is extremely cheap.
 - Saving configuration to disk is more expensive but is done infrequently
 
-
 ## Working With Your Mod's Configuration
 
 A simple example is below:

--- a/doc/directories.md
+++ b/doc/directories.md
@@ -4,7 +4,7 @@ If you've installed to a non-default location then finding the path is up to you
 
 | Directory | Description |
 | --------- |------------ |
-| Neos Install Directory | Contains the game install itself, the log directory, and the libraries directory | 
+| Neos Install Directory | Contains the game install itself, the log directory, and the libraries directory |
 | Log Directory | A `Log` directory within the Neos Install Directory. Contains the main game logs. |
 | Libraries Directory | A `Libraries` directory within the  Neos Install Directory. Plugins dlls go here.
 | Data Directory | Contains the local db, Unity's player.log, and local assets directory. Location can be changed with `-DataPath <path>` argument. |
@@ -21,28 +21,27 @@ If you've installed to a non-default location then finding the path is up to you
 | Temporary Directory | `%temp%\Solirax\NeosVR` |
 | Cache Directory | `%temp%\Solirax\NeosVR\Cache` |
 
-
 ## Linux Native
 
 | Description | Typical Path |
 | ----------- | ------------ |
 | Neos Install Directory (Steam) | `$HOME/.local/share/Steam/steamapps/common/NeosVR` |
 | Neos Install Directory (Standalone) | *unknown* |
-| Data Directory | *unknown* |
-| Temporary Directory | *unknown* |
-| Cache Directory |*unknown* |
+| Data Directory | `$HOME/.config/unity3d/Solirax/NeosVR` |
+| Temporary Directory | `/tmp/Solirax/NeosVR` |
+| Cache Directory | `/tmp/Solirax/NeosVR/Cache` |
 
 ## Linux Proton/WINE
 
 | Description | Typical Path |
 | ----------- | ------------ |
-| Neos Install Directory (Steam) | *unknown* |
+| Neos Install Directory (Steam) | `$HOME/.local/share/Steam/steamapps/common/NeosVR` |
 | Neos Install Directory (Standalone) | *unknown* |
-| Data Directory | *unknown* |
-| Temporary Directory | *unknown* |
-| Cache Directory |*unknown* |
+| Data Directory | `$HOME/.steam/steam/steamapps/compatdata/740250/pfx/drive_c/users/steamuser/AppData/LocalLow/Solirax/NeosVR` |
+| Temporary Directory | `$HOME/.steam/steam/steamapps/compatdata/740250/pfx/drive_c/users/steamuser/Temp/Solirax/NeosVR` |
+| Cache Directory | `$HOME/.steam/steam/steamapps/compatdata/740250/pfx/drive_c/users/steamuser/Temp/Solirax/NeosVR/Cache` |
 
-# Drive Notes
+## Drive Notes
 
 - The actual Neos install should be less than 1GB, but the log files can in certain cases be very large.
 - The cache can get very large, upwards of 30GB so make sure the drive you save cache to has plenty of space. Neos will benefit by having this on a faster drive (read: SSD). The cache directory can be deleted whenever you need without breaking Neos. The cache directory can be changed with the `-CachePath <file path>` launch option.

--- a/doc/directories.md
+++ b/doc/directories.md
@@ -2,7 +2,6 @@
 
 If you've installed to a non-default location then finding the path is up to you.
 
-
 | Directory | Description |
 | --------- |------------ |
 | Neos Install Directory | Contains the game install itself, the log directory, and the libraries directory | 
@@ -24,6 +23,7 @@ If you've installed to a non-default location then finding the path is up to you
 
 
 ## Linux Native
+
 | Description | Typical Path |
 | ----------- | ------------ |
 | Neos Install Directory (Steam) | `$HOME/.local/share/Steam/steamapps/common/NeosVR` |
@@ -33,6 +33,7 @@ If you've installed to a non-default location then finding the path is up to you
 | Cache Directory |*unknown* |
 
 ## Linux Proton/WINE
+
 | Description | Typical Path |
 | ----------- | ------------ |
 | Neos Install Directory (Steam) | *unknown* |
@@ -42,6 +43,7 @@ If you've installed to a non-default location then finding the path is up to you
 | Cache Directory |*unknown* |
 
 # Drive Notes
+
 - The actual Neos install should be less than 1GB, but the log files can in certain cases be very large.
 - The cache can get very large, upwards of 30GB so make sure the drive you save cache to has plenty of space. Neos will benefit by having this on a faster drive (read: SSD). The cache directory can be deleted whenever you need without breaking Neos. The cache directory can be changed with the `-CachePath <file path>` launch option.
 - The data directory contains your localDB as well as locally saved assets. This can get to be around 10GB, or more if you store a lot in your local home. The data directory can be changed with the `-DataPath <file path>` launch option. Deleting this will:

--- a/doc/directories.md
+++ b/doc/directories.md
@@ -37,9 +37,9 @@ If you've installed to a non-default location then finding the path is up to you
 | ----------- | ------------ |
 | Neos Install Directory (Steam) | `$HOME/.local/share/Steam/steamapps/common/NeosVR` |
 | Neos Install Directory (Standalone) | *unknown* |
-| Data Directory | `$HOME/.steam/steam/steamapps/compatdata/740250/pfx/drive_c/users/steamuser/AppData/LocalLow/Solirax/NeosVR` |
-| Temporary Directory | `$HOME/.steam/steam/steamapps/compatdata/740250/pfx/drive_c/users/steamuser/Temp/Solirax/NeosVR` |
-| Cache Directory | `$HOME/.steam/steam/steamapps/compatdata/740250/pfx/drive_c/users/steamuser/Temp/Solirax/NeosVR/Cache` |
+| Data Directory | `$HOME/.local/share/Steam/steamapps/compatdata/740250/pfx/drive_c/users/steamuser/AppData/LocalLow/Solirax/NeosVR` |
+| Temporary Directory | `$HOME/.local/share/Steam/steamapps/compatdata/740250/pfx/drive_c/users/steamuser/Temp/Solirax/NeosVR` |
+| Cache Directory | `$HOME/.local/share/Steam/steamapps/compatdata/740250/pfx/drive_c/users/steamuser/Temp/Solirax/NeosVR/Cache` |
 
 ## Drive Notes
 

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -1,24 +1,31 @@
 # Frequently Asked Questions
 
 ## Something is broken! Where can I get help?
+
 Please take a look at our [troubleshooting page](troubleshooting.md).
 
 ## Do you have a Discord server?
+
 Yes. [Here it is.](https://discord.gg/vCDJK9xyvm)
 
 ## What is a mod?
+
 Mods are .dll files loaded by NeosModLoader that change the behavior of your Neos client in some way. Unlike plugins, mods are specifically designed to work in multiplayer.
 
 ## What does NeosModLoader do?
+
 NeosModLoader is simply a Neos [plugin](https://wiki.neos.com/Plugins) that does a lot of the boilerplate necessary to get mods working in a reasonable way. In summary, it:
+
 1. Initializes earlier than a normal plugin
 2. Ensures that Neos's compatibility check doesn't prevent you from joining other players. For safety reasons this will only work if NeosModLoader is the only plugin.
 3. Loads mod .dll files and calls their `OnEngineInit()` function so the mods can begin executing
 
 ## Is using NeosModLoader allowed?
+
 Yes, so long as Neos's [Mod & Plugin Policy] is followed.
 
 ## Will people know I'm using mods?
+
 - By default, NeosModLoader does not do anything identifiable over the network. You will appear to be running the vanilla Neos version to any component that shows your version strings or compatibility hash.
 - If you are running other plugins, they will alter your version strings and compatibility hash.
 - NeosModLoader logs to the same log file Neos uses. If you send your logs to anyone it will be obvious that you are using a plugin. This is intended.
@@ -27,44 +34,55 @@ Yes, so long as Neos's [Mod & Plugin Policy] is followed.
 - If NeosModLoader breaks due to a bad install or a Neos update, it will be unable to hide its own existence.
 
 ## Are mods safe? 
+
 Mods are not sandboxed in any way. In other words, they run with the same level of privilege as Neos itself. A poorly written mod could cause performance or stability issues. A maliciously designed mod could give a malicious actor a dangerous level of control over your computer. **Make sure you only use mods from sources you trust.**
 
 If you aren't sure if you can trust a mod and you have some level of ability to read code, you can look at its source code. If the source code is unavailable or you suspect it may differ from the contents of the .dll file, you can inspect the mod with a [C# decompiler](https://www.google.com/search?q=c%23+decompiler). Things to be particularly wary of include:
+
 - Obfuscated code
 - Sending or receiving data over the internet
 - Interacting with the file system (reading, writing, or executing files from disk)
 
 ## Where does NeosModLoader log to?
+
 The regular Neos logs: `C:\Program Files (x86)\Steam\steamapps\common\NeosVR\Logs`
 
 ## Is NeosModLoader compatible with other mod loaders?
+
 Yes, **however** other mod loaders are likely to come with LibHarmony, and you need to ensure you only have one. Therefore you may need to remove 0Harmony.dll from your Neos install directory. If the foreign mod loader's LibHarmony version is significantly different from the standard Harmony 2 library, then it will not be compatible with NeosModLoader at all.
 
 ## Why did you build a custom mod loader for Neos?
+
 1. ~~Neos Plugins are given extra protections in the [Neos Guidelines](https://docs.google.com/document/d/1mqdbIvbj1b2LeFhNzfAASeTpRZk6vmbXISYLdTXTVR4/edit), and those same protections are not extended to a generic Unity mod loader.~~ This is no longer true, as modding Neos is now specifically allowed within Neos's [Mod & Plugin Policy].
 2. As Neos Plugins are officially supported we can expect them to continue working even through major engine changes, for example if Neos ever switches to a non-Unity engine.
 
 ## As a content creator, when is a mod the right solution?
+
 Check out this document for more detail: [Problem Solving Techniques](problem_solving_techniques.md).
 
 ## As a mod developer, why should I use NeosModLoader over a Neos Plugin?
+
 If you are just trying to make a new component or logix node, you should use a plugin. The plugin system is specifically designed for that.
 
 If you are trying to modify Neos's existing behavior without adding any new components, NeosModLoader offers the following:
+
 - [LibHarmony] is a dependency of NeosModLoader, so as a mod developer you don't need to worry about making sure it's installed
 - Neos Plugins normally break multiplayer compatibility. The NeosModLoader plugin has been specifically designed to remain compatible. This feature will only work if NeosModLoader.dll is the *only* plugin you are using.
 - Neos Plugins can normally execute when Local Home loads at the earliest. NeosModLoader begins executing significantly earlier, giving you more room to alter Neos's behavior before it finishes initializing.
 - Steam has a relatively small character limit on launch options, and every Neos plugin you install pushes you closer to that limit. Having more than a handful plugins will therefore prevent you from using Steam to launch the game, and NeosModLoader is unaffected by this issue.
 
 ## Can mods depend on other mods?
+
 Yes. All mod assemblies are loaded before any mod hooks are called, so no special setup is needed if your mod provides public methods.
 
 Mod hooks are called alphabetically by the mod filename, so you can purposefully alter your filename (`0_mod.dll`) to make sure your hooks run first.
 
 ## Can NeosModLoader load Neos plugins?
+
 No. You need to use `-LoadAssembly <path>` to load plugins. There is important plugin handling code that does not run for NeosModLoader mods.
 
 ## Are NeosModLoader mods plugins?
+
 No. NeosModLoader mods will not work if used as a Neos plugin.
 
 <!--- Link References -->

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -33,7 +33,7 @@ Yes, so long as Neos's [Mod & Plugin Policy] is followed.
 - If you wish to opt in to using your real version string you can set `advertiseversion=true` in the NeosModLoader.config file.
 - If NeosModLoader breaks due to a bad install or a Neos update, it will be unable to hide its own existence.
 
-## Are mods safe? 
+## Are mods safe?
 
 Mods are not sandboxed in any way. In other words, they run with the same level of privilege as Neos itself. A poorly written mod could cause performance or stability issues. A maliciously designed mod could give a malicious actor a dangerous level of control over your computer. **Make sure you only use mods from sources you trust.**
 

--- a/doc/how_nml_works.md
+++ b/doc/how_nml_works.md
@@ -1,7 +1,9 @@
 # Going Into Detail: How NeosModLoader Interfaces with Neos
+
 NeosModLoader only interfaces with Neos in two places: the hook and the compatibility hash.
 
 ## The Hook
+
 The hook is the point where Neos "hooks" into NeosModLoader, allowing it to begin execution.
 
 Typically, [plugins] use [components] to execute custom code. This is limiting as they can only begin execution once a world loads. Typically this involves putting a plugin's component into your local home.
@@ -11,6 +13,7 @@ The NeosModLoader plugin uses a different mechanism. Instead of using a componen
 This connector-based hook does not modify the Neos application, and only uses public Neos APIs.
 
 ## The Compatibility Hash
+
 [Neos plugins][plugin], when loaded, alter your client's compatibility hash from what a vanilla client would have. You cannot join a session unless your compatibility hash is an exact match with the host.
 
 Plugins are intended to add new features such as [components] and [LogiX nodes][logix] to the [data model], and altering the data model breaks multiplayer compatibility. This is why the compatibility hash exists, and why plugins alter it.

--- a/doc/linux.md
+++ b/doc/linux.md
@@ -6,7 +6,7 @@ The log directory on Linux is `$HOME/.local/share/Steam/steamapps/common/NeosVR/
 
 If your log contains the following, you need to set up a workaround for the issue.
 
-```
+```log
 System.IO.DirectoryNotFoundException: Could not find a part of the path "/home/myusername/.local/share/Steam/steamapps/common/NeosVR/Neos_Data\Managed/FrooxEngine.dll".
 ```
 

--- a/doc/making_mods.md
+++ b/doc/making_mods.md
@@ -1,27 +1,34 @@
 # Mod Creation Guide
+
 If you have some level of familiarity with C#, getting started making mods should not be too difficult.
 
 ## Basic Visual Studio setup
+
 1. Make a new .NET library against .NET version 4.6.2. You can use 4.7.2 if you absolutely need it in order to compile, but some features may not work.
 2. Add NeosModLoader.dll as a reference.
 3. Add references to Neos libraries as needed (`C:\Program Files (x86)\Steam\steamapps\common\NeosVR\Neos_Data\Managed`)
 4. Remove the reference to `System.Net.Http` as it will make the compiler angry
 
 ## Hooks
+
 ### `OnEngineInit()`
+
 Called once during FrooxEngine initialization.
 
 Happens **before** `OnEngineInit()`
+
 - Head device setup
 - Plugin initialization
 
 Happens **after** `OnEngineInit()`
+
 - Local DB initialization
 - Networking initialization
 - Audio initialization
 - Worlds loading, including Local home and Userspace
 
 ## Mod Configuration
+
 NeosModLoader provides a built-in configuration system that can be used to persist configuration values for mods. More information is available in the [configuration system documentation](config.md).
 
 ## Example Mod
@@ -56,16 +63,21 @@ namespace MyMod
     }
 }
 ```
+
 A [Template repo](https://github.com/EIA485/NeosTemplate/) is available.
+
 ## Full Example
+
 A working example mod is available here: https://github.com/zkxs/MotionBlurDisable
 
 It showcases the following:
+
 - A valid Visual Studio project setup
 - Using LibHarmony to patch a Neos method
 - Using Unity to alter all existing GameObjects of a certain type
 
 ## Additional Resources
+
 - [Quick C# Refresher](https://learnxinyminutes.com/docs/csharp/)
 - [LibHarmony Documentation](https://harmony.pardeike.net/)
 - [Unity API Documentation](https://docs.unity3d.com/ScriptReference/index.html)

--- a/doc/making_mods.md
+++ b/doc/making_mods.md
@@ -68,7 +68,7 @@ A [Template repo](https://github.com/EIA485/NeosTemplate/) is available.
 
 ## Full Example
 
-A working example mod is available here: https://github.com/zkxs/MotionBlurDisable
+A working example mod is available here: <https://github.com/zkxs/MotionBlurDisable>
 
 It showcases the following:
 

--- a/doc/modloader_config.md
+++ b/doc/modloader_config.md
@@ -1,6 +1,7 @@
 # Modloader Configuration
 
 NeosModLoader aims to have a reasonable default configuration, but certain things can be adjusted via an optional config file. The config file does not create itself automatically, but you can create it yourself by making a `NeosModLoader.config` file in the same directory as `NeosModLoader.dll`. `NeosModLoader.config` is a simple text file that supports keys and values in the following format:
+
 ```
 debug=true
 nomods=false

--- a/doc/modloader_config.md
+++ b/doc/modloader_config.md
@@ -2,7 +2,7 @@
 
 NeosModLoader aims to have a reasonable default configuration, but certain things can be adjusted via an optional config file. The config file does not create itself automatically, but you can create it yourself by making a `NeosModLoader.config` file in the same directory as `NeosModLoader.dll`. `NeosModLoader.config` is a simple text file that supports keys and values in the following format:
 
-```
+```ini
 debug=true
 nomods=false
 ```

--- a/doc/neos_guidelines.md
+++ b/doc/neos_guidelines.md
@@ -1,17 +1,19 @@
-# Is Modding Neos Allowed?
+# Modding related guidelines
+
+## Is Modding Neos Allowed?
 
 Yes!
 
 On January 11, 2022, an official [Mod & Plugin Policy] was released. Mods are now officially allowed, so long as the policy is followed.
 
-# Is Modding Good for Neos?
+## Is Modding Good for Neos?
 
 > Your scientists were so preoccupied with whether or not they could, they didn’t stop to think if they should.  
 > — Dr. Ian Malcolm
 
 My opinion is yes, mods are healthy for the game. You might have deduced this from the fact that I created a mod loader. But let's look at the pros and cons, and I'll try to be impartial.
 
-## The Pros
+### The Pros
 
 - Tomorrow's quality of life improvements, today. Sometimes the Neos team needs to direct their efforts elsewhere. Allowing the community to make temporary fixes pending a permanent solution is an easy win. Example: [MotionBlurDisable](https://github.com/zkxs/MotionBlurDisable), which won't be implemented in Neos until a full Settings redesign.
 - Mods let power users opt in to warranty-voiding tools. Sometimes a desired feature has a very niche audience and risks breaking in the future. But at the same time it can be very useful in the present. Example: [ExportNeosToJson](https://github.com/zkxs/ExportNeosToJson).
@@ -19,14 +21,14 @@ My opinion is yes, mods are healthy for the game. You might have deduced this fr
 <!-- - Potential to improve the game. If the planets align, what was once a mod could be integrated into the game proper. But let's be honest, it's going to be easier for Froox to build the feature himself than porting some random garbage code in from a mod... -->
 <!-- - Possible source of new developers. If you're hiring someone to program for Neos... why not hire someone who's *already* programming for Neos? -->
 
-## The Cons
+### The Cons
 
 - Risk of abuse. The more control users have over the game the more damage they can potentially do.
 - Risk of breakage. Users *should* be aware that mods void the warranty, but some people might complain in the wrong channels when mods break. And if things go very wrong there's potential for a mod to break an unmodified user over the network.
 - Misdirection of effort. If mods create a problem the Neos team has to step in and solve that's less time spent improving the game.
 <!-- - IP ramifications. Modding is a slippery slope to decompiling when the complete lack of documentation leaves you in the dark. But the same can be said for regular plugins. -->
 
-# Afterword
+## Afterword
 
 The [EULA], [guidelines] and [Mod & Plugin Policy] are subject to change. This document was last updated on **2022-01-12**, and may be out of date.
 

--- a/doc/neos_guidelines.md
+++ b/doc/neos_guidelines.md
@@ -5,12 +5,14 @@ Yes!
 On January 11, 2022, an official [Mod & Plugin Policy] was released. Mods are now officially allowed, so long as the policy is followed.
 
 # Is Modding Good for Neos?
+
 > Your scientists were so preoccupied with whether or not they could, they didn’t stop to think if they should.  
 > — Dr. Ian Malcolm
 
 My opinion is yes, mods are healthy for the game. You might have deduced this from the fact that I created a mod loader. But let's look at the pros and cons, and I'll try to be impartial.
 
 ## The Pros
+
 - Tomorrow's quality of life improvements, today. Sometimes the Neos team needs to direct their efforts elsewhere. Allowing the community to make temporary fixes pending a permanent solution is an easy win. Example: [MotionBlurDisable](https://github.com/zkxs/MotionBlurDisable), which won't be implemented in Neos until a full Settings redesign.
 - Mods let power users opt in to warranty-voiding tools. Sometimes a desired feature has a very niche audience and risks breaking in the future. But at the same time it can be very useful in the present. Example: [ExportNeosToJson](https://github.com/zkxs/ExportNeosToJson).
 - The classic "if you outlaw guns only outlaws will have guns" argument. Example: \[redacted\].
@@ -18,12 +20,14 @@ My opinion is yes, mods are healthy for the game. You might have deduced this fr
 <!-- - Possible source of new developers. If you're hiring someone to program for Neos... why not hire someone who's *already* programming for Neos? -->
 
 ## The Cons
+
 - Risk of abuse. The more control users have over the game the more damage they can potentially do.
 - Risk of breakage. Users *should* be aware that mods void the warranty, but some people might complain in the wrong channels when mods break. And if things go very wrong there's potential for a mod to break an unmodified user over the network.
 - Misdirection of effort. If mods create a problem the Neos team has to step in and solve that's less time spent improving the game.
 <!-- - IP ramifications. Modding is a slippery slope to decompiling when the complete lack of documentation leaves you in the dark. But the same can be said for regular plugins. -->
 
 # Afterword
+
 The [EULA], [guidelines] and [Mod & Plugin Policy] are subject to change. This document was last updated on **2022-01-12**, and may be out of date.
 
 [eula]: https://store.steampowered.com/eula/740250_eula_0

--- a/doc/neos_standalone_setup.md
+++ b/doc/neos_standalone_setup.md
@@ -1,7 +1,9 @@
 # Neos Standalone Setup
+
 How to have steam hour logging, mods, and NCR simultaneously
 
 ## Setup
+
 1. Grab and run [NeosPublicSetup.exe](https://assets.neos.com/install/NeosPublicSetup.exe) 
 2. Install it wherever you want to. The default `C:\Neos` location is fine if you don't have multiple drives to worry about. If you do, check the [drive notes](directories.md/#drive-notes). **Do not merge your standalone install into your Steam install!** While merging installs can technically work it can easily create more problems than it solves.  
    ![NeosPublicSetup.exe screenshot](img/NeosPublicSetup.png)
@@ -21,5 +23,6 @@ How to have steam hour logging, mods, and NCR simultaneously
 13. Launch Neos using your new non-steam game shortcut. Steam will track playtime on the Steam version of the game even though you are running the standalone version.
 
 ## Notes
+
 - You will need to run `NeosProLauncher.exe` every time you want to update. You never need actually use its launch buttons, as it does not support launch options which are required for plugins/mods.
 - The logs you're used to finding in `C:\Program Files (x86)\Steam\steamapps\common\NeosVR\Logs` will go to `C:\Neos\app\Logs` now.

--- a/doc/neos_standalone_setup.md
+++ b/doc/neos_standalone_setup.md
@@ -4,7 +4,7 @@ How to have steam hour logging, mods, and NCR simultaneously
 
 ## Setup
 
-1. Grab and run [NeosPublicSetup.exe](https://assets.neos.com/install/NeosPublicSetup.exe) 
+1. Grab and run [NeosPublicSetup.exe](https://assets.neos.com/install/NeosPublicSetup.exe)
 2. Install it wherever you want to. The default `C:\Neos` location is fine if you don't have multiple drives to worry about. If you do, check the [drive notes](directories.md/#drive-notes). **Do not merge your standalone install into your Steam install!** While merging installs can technically work it can easily create more problems than it solves.  
    ![NeosPublicSetup.exe screenshot](img/NeosPublicSetup.png)
 3. Go to the directory you installed to and run `NeosProLauncher.exe`. Wait for it to finish patching. **Do not use either of the launch buttons!**  
@@ -15,12 +15,12 @@ How to have steam hour logging, mods, and NCR simultaneously
    ![add non-steam game screenshot](img/add_non_steam_game.png)
 7. Hit the "browse" button, and go to `C:\Neos\app\Neos.exe` (or wherever is applicable given your install directory)
 8. Hit the "add selected programs" button.
-9.  Right click the newly added game in your library, and go to "properties"  
+9. Right click the newly added game in your library, and go to "properties"  
    ![right click properties screenshot](img/non_steam_game_properties_1.png)
-11. Configure the non-steam game with the same launch options you used on the Steam game. Optionally, give it a more descriptive name and check the "Include in VR Library" checkbox.  
+10. Configure the non-steam game with the same launch options you used on the Steam game. Optionally, give it a more descriptive name and check the "Include in VR Library" checkbox.  
     ![non steam game properties screenshot](img/non_steam_game_properties_2.png)  
-12. Install NeosModLoader into the standalone version [as you normally would for the steam version](../README.md#installation), but using your `C:\Neos\app` directory instead.
-13. Launch Neos using your new non-steam game shortcut. Steam will track playtime on the Steam version of the game even though you are running the standalone version.
+11. Install NeosModLoader into the standalone version [as you normally would for the steam version](../README.md#installation), but using your `C:\Neos\app` directory instead.
+12. Launch Neos using your new non-steam game shortcut. Steam will track playtime on the Steam version of the game even though you are running the standalone version.
 
 ## Notes
 

--- a/doc/problem_solving_techniques.md
+++ b/doc/problem_solving_techniques.md
@@ -1,22 +1,29 @@
 # Problem Solving Techniques
+
 Neos has many different ways to solve a problem: Components, Logix, HTTP connections to an external server, refhacking, plugins, and now mods. Some of these methods are supported, some aren't. We'll do a quick rundown of the methods and where they're applicable.
 
 ## Components and Logix
+
 If you can solve a problem with Components and/or Logix that's probably the approach you should take, as the more advanced techniques are likely to be overkill.
 
 ## HTTP Connections
-Neos provides Logix nodes to communicate with an external server via HTTP GET, POST, and websockets. This is great for
+
+Neos provides Logix nodes to communicate with an external server via HTTP GET, POST, and websockets. This is great for:
+
 - Heavy data processing that LogiX isn't well suited for
 - Advanced data persistence (for simple things consider using Cloud Variables)
 - Connecting Logix across multiple sessions
 
 ## RefHacking
+
 Refhacking is a method that at considerable performance cost can get you an extremely sketchy but working component access. Refhacking is not supported and will break in the future, but sometimes it is the only way to do certain things without waiting for real component access.
 
 My personal advice is to just put your component access ideas into a todo list and do them once we have real support. It's not fun when your creations break.
 
 ## Plugins
+
 Plugins let you add new components and Logix nodes, but at the cost of breaking multiplayer compatibility. If you like multiplayer, they aren't going to give you much quality-of-life because you'll be forced into singleplayer to use them. Plugins are great for automating menial tasks that you do very infrequently, for example monopacking is nightmarish to do by hand but can be done with a single button via a plugin.
 
 ## Mods
+
 Mods do **not** let you add new components and Logix nodes, but they do work in multiplayer. They are limited in what they can do without breaking multiplayer compatibility. You can imagine them as a "controlled desync". They are well-suited for minor quality-of-life tweaks, for example preventing your client from rendering motion blur. Making a larger feature with a mod isn't a great option, as you cannot rely on other clients also having the mod.

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -39,9 +39,10 @@ If the problem is Windows blocking the DLL file:
 1. Right click on the NeosModLoader.dll file and open the properties.
 2. Check the unblock checkbox, and hit OK.  
    ![add non-steam game screenshot](img/windows_unblock.png)
-4. Repeat this process for 0Harmony.dll.
+3. Repeat this process for 0Harmony.dll.
 
 If the problem is your antivirus:
+
 1. Make sure your antivirus has not quarantined or deleted NeosModLoader.dll or 0Harmony.dll.
 2. Add an exception to your antivirus. If you're uncomfortable adding an exception, you have options:
    - Don't run NeosModLoader.
@@ -66,10 +67,10 @@ Possibility 1: Harmony is not installed correctly.
 1. Your log contains the following:
 
    ```log
-   18:36:34.158 (  0 FPS)	[ERROR][NeosModLoader] Exception in execution hook!
+   18:36:34.158 (  0 FPS) [ERROR][NeosModLoader] Exception in execution hook!
    System.IO.FileNotFoundException: Could not load file or assembly '0Harmony, Version=2. 2.0.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies.
    File name: '0Harmony, Version=2.2.0.0, Culture=neutral, PublicKeyToken=null'
-   at NeosModLoader.ExecutionHook..cctor () [0x00000] in  <67d6a64d7ebf403f83f1a8b1d8c03d22>:0 
+   at NeosModLoader.ExecutionHook..cctor () [0x00000] in  <67d6a64d7ebf403f83f1a8b1d8c03d22>:0
    ```
 
 2. Go back to the [installation instructions](../README.md#installation) and install Harmony to the correct location.
@@ -79,12 +80,13 @@ Possibility 2: You are using an old version of NeosModLoader.
 1. Check your log for a line like this:
 
   ```log
-  5:26:24 PM.823 (  0 FPS)	[INFO] [NeosModLoader] NeosModLoader v1.8.0 starting up!
+  5:26:24 PM.823 (  0 FPS) [INFO] [NeosModLoader] NeosModLoader v1.8.0 starting up!
   ```
 
 2. Verify your NeosModLoader version matches [the latest release](https://github.com/zkxs/NeosModLoader/releases/latest).
 
 Possibility 3: NeosModLoader itself is broken, even on the latest version. This can happen in rare circumstances when Neos updates.
+
 1. Please report the issue on [our Discord][Neos Modding Discord] or in [a GitHub issue](https://github.com/zkxs/NeosModLoader/issues).
 2. Wait for a fix.
 

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -5,6 +5,7 @@ Below we will go over some common problems and their solutions.
 ## NeosModLoader Isn't Being Loaded
 
 **Symptoms:**
+
 - After starting the game nothing has changed, and it appears completely unmodified.
 - Logs don't say anything about "NeosModLoader"
 
@@ -13,11 +14,13 @@ Below we will go over some common problems and their solutions.
 If the problem is the `-LoadAssembly` setup:
 
 1. Check the logs (`C:\Program Files (x86)\Steam\steamapps\common\NeosVR\Logs`). If you search the log for "NeosModLoader" you should find a section that looks like this:
+
    ```log
    5:26:23 PM.305 (  0 FPS)    Argument: Neos.exe
    5:26:23 PM.305 (  0 FPS)    Argument: -LoadAssembly
    5:26:23 PM.305 (  0 FPS)    Argument: Libraries\NeosModLoader.dll
    ```
+
    If those logs are absent it indicates you are not passing the `-LoadAssembly Libraries\NeosModLoader.dll` argument to Neos correctly.
 2. Double check your shortcut to Neos.
 3. Check a known-working shortcut.
@@ -28,9 +31,11 @@ If the problem is the `-LoadAssembly` setup:
    5. Neos should start and load NeosModLoader as expected.
 
 If the problem is the FrooxEngine.dll path on Linux:
+
 1. If you are on Linux, make sure you've followed the [extra Linux instructions](linux.md).
 
 If the problem is Windows blocking the DLL file:
+
 1. Right click on the NeosModLoader.dll file and open the properties.
 2. Check the unblock checkbox, and hit OK.  
    ![add non-steam game screenshot](img/windows_unblock.png)
@@ -46,47 +51,59 @@ If the problem is your antivirus:
 ## NeosModLoader Loads, but Errors Out
 
 **Symptoms:**
+
 - Mods are not loading
 - All of your contacts have a magenta border and appear to be using an incompatible version
 
 **Fix:**
+
 1. Verify that the [installation instructions](../README.md#installation) were followed correctly
 2. If you are using the [standalone](neos_standalone_setup.md) or [Linux](linux.md) builds, make sure you've followed the extra steps.
 3. Check the logs (`C:\Program Files (x86)\Steam\steamapps\common\NeosVR\Logs`). There are a few things you are likely to find:
 
 Possibility 1: Harmony is not installed correctly.
+
 1. Your log contains the following:
+
    ```log
    18:36:34.158 (  0 FPS)	[ERROR][NeosModLoader] Exception in execution hook!
    System.IO.FileNotFoundException: Could not load file or assembly '0Harmony, Version=2. 2.0.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies.
    File name: '0Harmony, Version=2.2.0.0, Culture=neutral, PublicKeyToken=null'
    at NeosModLoader.ExecutionHook..cctor () [0x00000] in  <67d6a64d7ebf403f83f1a8b1d8c03d22>:0 
    ```
+
 2. Go back to the [installation instructions](../README.md#installation) and install Harmony to the correct location.
 
 Possibility 2: You are using an old version of NeosModLoader.
+
 1. Check your log for a line like this:
+
   ```log
   5:26:24 PM.823 (  0 FPS)	[INFO] [NeosModLoader] NeosModLoader v1.8.0 starting up!
   ```
+
 2. Verify your NeosModLoader version matches [the latest release](https://github.com/zkxs/NeosModLoader/releases/latest).
-    
+
 Possibility 3: NeosModLoader itself is broken, even on the latest version. This can happen in rare circumstances when Neos updates.
 1. Please report the issue on [our Discord][Neos Modding Discord] or in [a GitHub issue](https://github.com/zkxs/NeosModLoader/issues).
 2. Wait for a fix.
 
 ## Multiplayer Compatibility is Broken, but Everything Else Works
+
 **Symptoms:**
+
 - Mods are loading
 - All of your contacts have a magenta border and appear to be using an incompatible version
 
 **Fix:**
+
 1. Make sure you are not running more than one plugin. For safety reasons, NeosModLoader will only spoof your version if it is the only plugin running.
 2. If you absolutely need your other plugin and understand the risks there is a [configuration](modloader_config.md) available to force version spoofing.
 
 ## A Mod is Breaking Neos
 
 **Symptoms:**
+
 - Modded Neos is broken or crashing unexpectedly
 - Unmodified Neos is working
 


### PR DESCRIPTION
Whilst investigating a separate possible NML addition, I noticed quite a few minor problems and thought I'd fix them first;

- Updated harmony version
- Changed csproj old "Plugins" build option to "Libraries"
- Markdown files are consistently missing newlines
  - usually it's considered best practice to have headings, code blocks and lists surrounded by new lines
  - Also only having a single h1 level heading
- Added linux paths to docs
- Other misc changes, mostly removing extra spaces and normalizing tabs to spaces, and fixing numbered list numbers