### PR TITLE
Make mod loading logging a bit cleaner

### DIFF
--- a/NeosModLoader/ModConfigurationDefinitionBuilder.cs
+++ b/NeosModLoader/ModConfigurationDefinitionBuilder.cs
@@ -80,7 +80,6 @@ namespace NeosModLoader
             }
 
             ModConfigurationKey fieldValue = (ModConfigurationKey)field.GetValue(field.IsStatic ? null : Owner);
-            //Logger.DebugInternal($"{Owner.Name} autoregistering config key: {field}");
             Keys.Add(fieldValue);
         }
 

--- a/NeosModLoader/ModConfigurationDefinitionBuilder.cs
+++ b/NeosModLoader/ModConfigurationDefinitionBuilder.cs
@@ -80,7 +80,7 @@ namespace NeosModLoader
             }
 
             ModConfigurationKey fieldValue = (ModConfigurationKey)field.GetValue(field.IsStatic ? null : Owner);
-            Logger.DebugInternal($"{Owner.Name} autoregistering config key: {field}");
+            //Logger.DebugInternal($"{Owner.Name} autoregistering config key: {field}");
             Keys.Add(fieldValue);
         }
 
@@ -90,11 +90,7 @@ namespace NeosModLoader
             {
                 return new ModConfigurationDefinition(Owner, ConfigVersion, Keys, AutoSaveConfig);
             }
-            else
-            {
-                Logger.DebugInternal($"{Owner.Name} had no defined keys. Building null config.");
-                return null;
-            }
+            return null;
         }
     }
 }

--- a/NeosModLoader/ModLoader.cs
+++ b/NeosModLoader/ModLoader.cs
@@ -109,8 +109,6 @@ namespace NeosModLoader
             Harmony harmony = new Harmony("net.michaelripley.neosmodloader");
             ModConfiguration.RegisterShutdownHook(harmony);
 
-            Logger.MsgInternal($"loading mods done, beginning hooks");
-
             foreach (LoadedNeosMod mod in LoadedMods)
             {
                 try

--- a/NeosModLoader/ModLoader.cs
+++ b/NeosModLoader/ModLoader.cs
@@ -248,6 +248,7 @@ namespace NeosModLoader
 
         private static void HookMod(LoadedNeosMod mod)
         {
+            Logger.DebugInternal($"calling OnEngineInit for {mod.NeosMod.Name}");
             try
             {
                 mod.NeosMod.OnEngineInit();

--- a/NeosModLoader/ModLoader.cs
+++ b/NeosModLoader/ModLoader.cs
@@ -248,7 +248,7 @@ namespace NeosModLoader
 
         private static void HookMod(LoadedNeosMod mod)
         {
-            Logger.DebugInternal($"calling OnEngineInit for {mod.NeosMod.Name}");
+            Logger.DebugInternal($"calling OnEngineInit() for [{mod.NeosMod.Name}]");
             try
             {
                 mod.NeosMod.OnEngineInit();

--- a/NeosModLoader/ModLoader.cs
+++ b/NeosModLoader/ModLoader.cs
@@ -40,7 +40,7 @@ namespace NeosModLoader
 
             string modDirectory = Path.Combine(Directory.GetCurrentDirectory(), "nml_mods");
 
-            Logger.DebugInternal($"loading mods from {modDirectory}");
+            Logger.MsgInternal($"loading mods from {modDirectory}");
 
             // generate list of assemblies to load
             ModAssembly[] modsToLoad = null;
@@ -108,6 +108,8 @@ namespace NeosModLoader
 
             Harmony harmony = new Harmony("net.michaelripley.neosmodloader");
             ModConfiguration.RegisterShutdownHook(harmony);
+
+            Logger.MsgInternal($"loading mods done, beginning hooks");
 
             foreach (LoadedNeosMod mod in LoadedMods)
             {

--- a/NeosModLoader/ModLoader.cs
+++ b/NeosModLoader/ModLoader.cs
@@ -238,6 +238,7 @@ namespace NeosModLoader
                 }
 
                 LoadedNeosMod loadedMod = new LoadedNeosMod(neosMod, mod);
+                Logger.MsgInternal($"loaded mod [{neosMod.Name}/{neosMod.Version}] ({Path.GetFileName(mod.File)}) by {neosMod.Author}");
                 loadedMod.ModConfiguration = ModConfiguration.LoadConfigForMod(loadedMod);
                 return loadedMod;
             }
@@ -245,7 +246,6 @@ namespace NeosModLoader
 
         private static void HookMod(LoadedNeosMod mod)
         {
-            Logger.MsgInternal($"loaded mod {mod.NeosMod.Name} {mod.NeosMod.Version} from {mod.ModAssembly.File}");
             try
             {
                 mod.NeosMod.OnEngineInit();


### PR DESCRIPTION
Removes the very verbose configuration logging, and cleans up logging of loading mods.
The log messages would now happen as after mods are actually loaded by NML instead of when the hooks for a mod are going to be ran.

Example log section when loading mods:
```log
...
15:29:16.901 (  0 FPS)  [INFO] [NeosModLoader] loading mods from /home/lj/.local/share/Steam/steamapps/common/NeosVR/nml_mods
15:29:16.907 (  0 FPS)  [INFO] [NeosModLoader] loaded mod [ContactsPublishedWorldsButton/1.0.0] (ContactsPublishedWorldsButton.dll) by badhaloninja
15:29:16.911 (  0 FPS)  [INFO] [NeosModLoader] loaded mod [Dark Mode LogiX Browser/1.0.4] (DarkLogiXBrowser.dll) by Cyro
15:29:16.915 (  0 FPS)  [INFO] [NeosModLoader] loaded mod [GetItemLink/1.1.0] (GetItemLink.dll) by eia485
15:29:16.915 (  0 FPS)  [INFO] [NeosModLoader] loaded mod [Latest Log/0.0.1] (LatestLog.dll) by ljoonal
15:29:16.916 (  0 FPS)  [INFO] [NeosModLoader] loaded mod [MotionBlurDisable/1.1.0] (MotionBlurDisable.dll) by runtime
15:29:16.918 (  0 FPS)  [INFO] [NeosModLoader] loaded mod [NeosPTTKeybinds/1.1.0] (NeosPTTKeybinds.dll) by Delta
15:29:16.959 (  0 FPS)  [INFO] [NeosModLoader] loaded mod [VideoPlayerFix/3.2.0] (NeosVideoPlayerFix.dll) by Fro Zen
15:29:16.974 (  0 FPS)  [INFO] [NeosModLoader] loaded mod [SesisonTweaks/2.0.1] (SessionTweaks.dll) by kazu0617
15:29:17.148 (  0 FPS)  [INFO] [NeosModLoader] loading mods done, beginning hooks
15:29:17.472 (  0 FPS)  [INFO] [NeosModLoader/Latest Log] Going to create symlink from: `/home/lj/.local/share/Steam/steamapps/common/NeosVR/Logs/BlueArc - 2022.1.28.1335 - 2022-03-31 15_29_13.log` to `/home/lj/.local/share/Steam/steamapps/common/NeosVR/Latest.log`
...
```