### PR TITLE
Fix for 1.9.0 Enum handling

### DIFF
--- a/NeosModLoader/JsonConverters/EnumConverter.cs
+++ b/NeosModLoader/JsonConverters/EnumConverter.cs
@@ -1,0 +1,53 @@
+﻿using Newtonsoft.Json;
+using System;
+
+namespace NeosModLoader.JsonConverters
+{
+    // serializes and deserializes enums as strings
+    class EnumConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType.IsEnum;
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            // handle old behavior where enums were serialized as underlying type
+            Type underlyingType = Enum.GetUnderlyingType(objectType);
+            if (TryConvert(reader.Value, underlyingType, out object deserialized))
+            {
+                Logger.DebugInternal($"Deserializing a BaseX type: {objectType} from a {reader.Value.GetType()}");
+                return deserialized;
+            }
+
+            // handle new behavior where enums are serialized as strings
+            if (reader.Value is string serialized)
+            {
+                return Enum.Parse(objectType, serialized);
+            }
+
+            throw new ArgumentException($"Could not deserialize a BaseX type: {objectType} from a {reader.Value.GetType()}. Expected underlying type was {underlyingType}");
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            string serialized = Enum.GetName(value.GetType(), value);
+            writer.WriteValue(serialized);
+        }
+
+        private bool TryConvert(object value, Type newType, out object converted)
+        {
+            try
+            {
+                converted = Convert.ChangeType(value, newType);
+                return true;
+            }
+            catch
+            {
+                converted = null;
+                return false;
+            }
+        }
+    }
+}

--- a/NeosModLoader/JsonConverters/NeosPrimitiveConverter.cs
+++ b/NeosModLoader/JsonConverters/NeosPrimitiveConverter.cs
@@ -11,13 +11,19 @@ namespace NeosModLoader.JsonConverters
 
         public override bool CanConvert(Type objectType)
         {
-            return BASEX.Equals(objectType.Assembly) && Coder.IsNeosPrimitive(objectType);
+            // handle all non-enum Neos Primitives in the BaseX assembly
+            return !objectType.IsEnum && BASEX.Equals(objectType.Assembly) && Coder.IsNeosPrimitive(objectType);
         }
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            string serialized = (string)reader.Value;
-            return typeof(Coder<>).MakeGenericType(objectType).GetMethod("DecodeFromString").Invoke(null, new object[] { serialized });
+            if (reader.Value is string serialized)
+            {
+                // use Neos's built-in decoding if the value was serialized as a string
+                return typeof(Coder<>).MakeGenericType(objectType).GetMethod("DecodeFromString").Invoke(null, new object[] { serialized });
+            }
+
+            throw new ArgumentException($"Could not deserialize a BaseX type: {objectType} from a {reader.Value.GetType()}");
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/NeosModLoader/ModConfiguration.cs
+++ b/NeosModLoader/ModConfiguration.cs
@@ -172,6 +172,7 @@ namespace NeosModLoader
                 Logger.DebugInternal($"Using {defaultConverters.Count()} default json converters");
                 converters.AddRange(defaultConverters);
             }
+            converters.Add(new EnumConverter());
             converters.Add(new NeosPrimitiveConverter());
             settings.Converters = converters;
             return JsonSerializer.Create(settings);

--- a/NeosModLoader/ModLoader.cs
+++ b/NeosModLoader/ModLoader.cs
@@ -12,7 +12,7 @@ namespace NeosModLoader
         /// <summary>
         /// NeosModLoader's version
         /// </summary>
-        public static readonly string VERSION = "1.9.0";
+        public static readonly string VERSION = "1.9.1";
         private static readonly Type NEOS_MOD_TYPE = typeof(NeosMod);
         private static List<LoadedNeosMod> LoadedMods = new List<LoadedNeosMod>(); // used for mod enumeration
         internal static Dictionary<Assembly, NeosMod> AssemblyLookupMap = new Dictionary<Assembly, NeosMod>(); // used for logging

--- a/NeosModLoader/Properties/AssemblyInfo.cs
+++ b/NeosModLoader/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.9.0.0")]
-[assembly: AssemblyFileVersion("1.9.0.0")]
+[assembly: AssemblyVersion("1.9.1.0")]
+[assembly: AssemblyFileVersion("1.9.1.0")]

--- a/NeosModLoader/SplashChanger.cs
+++ b/NeosModLoader/SplashChanger.cs
@@ -10,22 +10,27 @@ namespace NeosModLoader
     {
         private static bool failed = false;
         // Returned true means success, false means something went wrong.
-        internal static bool SetCustom(string text) {
+        internal static bool SetCustom(string text)
+        {
             if (ModLoaderConfiguration.Get().HideVisuals) return true;
-            try {
+            try
+            {
                 // VerboseInit does extra logging, so turning it if off while we change the phase.
                 bool ogVerboseInit = Engine.Current.VerboseInit;
                 Engine.Current.VerboseInit = false;
                 Traverse.Create(Engine.Current)
-                    .Method("UpdateInitPhase", new Type[] {typeof(string), typeof(bool)})
+                    .Method("UpdateInitPhase", new Type[] { typeof(string), typeof(bool) })
                     .GetValue("~ NeosModLoader ~", false);
                 Traverse.Create(Engine.Current)
-                    .Method("UpdateInitSubphase", new Type[] {typeof(string), typeof(bool)})
+                    .Method("UpdateInitSubphase", new Type[] { typeof(string), typeof(bool) })
                     .GetValue(text, false);
                 Engine.Current.VerboseInit = ogVerboseInit;
                 return true;
-            } catch (Exception ex) {
-                if (!failed) {
+            }
+            catch (Exception ex)
+            {
+                if (!failed)
+                {
                     Logger.WarnInternal("Splash change failed: " + ex.ToString());
                     failed = true;
                 }


### PR DESCRIPTION
This allows existing pre-1.9 configs with enums to be deserialized gracefully, while all new saved enums will turn into strings from this point on.